### PR TITLE
Fix aftermath build

### DIFF
--- a/libaftermath-core/src/ansi_extras.h
+++ b/libaftermath-core/src/ansi_extras.h
@@ -20,10 +20,9 @@
 #define AM_ANSI_EXTRAS_H
 
 #include "safe_alloc.h"
+#include <fcntl.h>
 #include <stdint.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -192,12 +191,17 @@ am_strreplace(char* haystack, const char* needle, const char* replacement)
  * -1, otherwise the size of the file. */
 static inline off_t am_file_size(const char* filename)
 {
-	struct stat stat_buf;
+	int fd;
+	off_t fsize;
 
-	if(stat(filename, &stat_buf) == -1)
+	fd = open(filename, O_RDONLY);
+	if (fd < 0)
 		return -1;
-
-	return stat_buf.st_size;
+	fsize = lseek(fd, 0, SEEK_END);
+	close(fd);
+	if (fsize < 0)
+		return -1;
+	return fsize;
 }
 
 char* am_strdupn(const char* s, size_t len);

--- a/libaftermath-core/src/object_notation.c
+++ b/libaftermath-core/src/object_notation.c
@@ -908,10 +908,13 @@ struct am_object_notation_node* am_object_notation_load(const char* filename)
 	off_t size;
 	struct am_object_notation_node* ret = NULL;
 
-	if((size = am_file_size(filename)) == -1)
+	if((fd = open(filename, O_RDONLY)) == -1)
 		goto out;
 
-	if((fd = open(filename, O_RDONLY)) == -1)
+	if ((size = lseek(fd, 0, SEEK_END)) < 0)
+		goto out;
+
+	if (lseek(fd, 0, SEEK_SET) < 0)
 		goto out;
 
 	if((str = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0)) == MAP_FAILED)


### PR DESCRIPTION
Aftermath build fails on recent system when the C header sys/stat.h is
included in C++ code base. Types like "__u64" generate an error for the
C++ compiler.

This patch uses open and lseek in place of stat to obtain the file size,
getting rid of the header requirement.